### PR TITLE
Kill process if lockfile already exists

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -298,7 +298,14 @@ try:
         LockFile = f"ElevenClockRunning{nowTime}"
         LockFilePath = os.path.join(os.path.expanduser("~"), ".elevenclock", LockFile)
         LockFileLocation = os.path.join(os.path.expanduser("~"), ".elevenclock")
-        setSettings(LockFile, True, False)
+        try:
+            # try to create lockfile, exit if it already exists since this means another process started at the same time
+            open(LockFilePath, "x").close()
+        except FileExistsError as e:
+            globals.newInstanceLaunched = True
+            print("🟠 KILLING, LOCKFILE ALREADY EXISTS")
+            killSignal.infoSignal.emit("", "")
+            return
         while True:
             try:
                 if os.path.isfile(os.path.join(LockFileLocation, "ReloadClocks")):


### PR DESCRIPTION
I frequently end up with multiple instances of ElevenClock when connecting/disconnecting my laptop from my dock which has 3 monitors attached. 

A new instance is started each time a monitor is attached/detached and the lockfile for each is supposed to have a unique name based on the timestamp when the process starts. I have found that several processes end up with the exact same timestamp for the lockfile name.

This fixes that by exiting the process if the lockfile already exists. 