### PR TITLE
adding support for expressions of the for   {x+/-y} to allow for offsets

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -1257,7 +1257,7 @@ try:
             
             while True:
                 try:
-                    timeStr = datetime.datetime.fromtimestamp(time.time()-self.internetTimeOffset).strftime(self.clockFormat.replace("\u200a", "hairsec")).replace("hairsec", HAIRSEC_VAR)
+                    timeStr = evaluate_expression_string(datetime.datetime.fromtimestamp(time.time()-self.internetTimeOffset).strftime(self.clockFormat.replace("\u200a", "hairsec")).replace("hairsec", HAIRSEC_VAR))
                     if SHOULD_FIX_SECONDS:
                         try:
                             secs = datetime.datetime.fromtimestamp(time.time()-self.internetTimeOffset).strftime("%S")

--- a/elevenclock/settings.py
+++ b/elevenclock/settings.py
@@ -3009,7 +3009,7 @@ class QSettingsLineEditCheckBox(QSettingsCheckBox):
         else:
             try:
                 currtext = self.edit.toPlainText()
-                self.preview.setText(datetime.datetime.now().strftime(currtext.replace("\u200a", "hairsec")).replace("hairsec", "\u200a"))
+                self.preview.setText(evaluate_expression_string(datetime.datetime.now().strftime(currtext.replace("\u200a", "hairsec")).replace("hairsec", "\u200a")))
             except Exception as e:
                 self.preview.setText(_("Invalid time format\nPlease follow the\nC 1989 Standards"))
                 report(e)

--- a/elevenclock/tools.py
+++ b/elevenclock/tools.py
@@ -32,6 +32,7 @@ import pythoncom
 import win32process
 import win32api
 import win32con
+import re
 
 specificSettings = {}
 missingTranslationList = []
@@ -130,6 +131,32 @@ def readRegedit(aKey, sKey, default, storage=winreg.HKEY_CURRENT_USER):
         except Exception as e:
             report(e)
             return default
+
+def evaluate_simple_expression(expression: str):  # supported expressions are of form x +/- y
+        tokens = re.split(r'(\+|\-)', expression)
+        result = int(tokens[0].strip())
+
+        for i in range(1, len(tokens), 2):
+            operator = tokens[i].strip()
+            operand = int(tokens[i + 1].strip())
+
+            if operator == "+":
+                result += operand
+            elif operator == "-":
+                result -= operand
+
+        return result
+
+def evaluate_expression_string(s: str):
+    def evaluate_match(match):
+        expression = match.group(1)
+        if re.fullmatch(r'\d+(\s*[\+\-]\s*\d+)*', expression): # a valid expression is of form x +/- y
+            return str(evaluate_simple_expression(expression))
+        else:
+            return match.group(0)  # Return the original text if not a valid expression
+
+    return re.sub(r'\{([^}]*)\}', evaluate_match, s) # search for expressions of form  {****} and replace using evaluate_match
+
 
 def getColors() -> list:
     colors = ['215,226,228', '160,174,183', '101,116,134', '81,92,107', '69,78,94', '41,47,64', '15,18,36', '239,105,80']


### PR DESCRIPTION
I use ElevenClock in my organization to display the current work week (%W) using the custom formatting options (it's very useful thanks!). Unfortunately my organization uses a different definition of work week so some years there is an off by one error. It looks like ElevenClock uses the strftime C function which defines week 1 as starting on the first Monday. There is an ISO standard (ISO 8601) that defines things differently (Week 1 is the first week with a majority of its days in Jan), and my org uses a third definition.

My recommendation is to allow offsets/expressions in the custom data formatting to solve this problem more generally. e.g

%a {%W+1}.%w to add 1 week

I imagine it could be useful for other offsets I'm not thinking of.

I'm open to other solutions, but I have already implemented a fix for myself using a simple evaluation function that supports basic addition and subtraction inside {}'s as above that wraps the calls to strftime.

If there is interest I would be happy to create a pull request so others could benefit. It's a relatively small change, but I personally know a bunch of folks that would find it very useful.